### PR TITLE
Support specifying cluster addons

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -7,6 +7,7 @@ data "template_file" "cluster-spec" {
     channel            = "${var.channel}"
     disable-sg-ingress = "${var.disable-sg-ingress}"
     cloud-labels       = "${join("\n", data.template_file.cloud-labels.*.rendered)}"
+    addons             = "${join("", data.template_file.addons.*.rendered)}"
     kube-dns-domain    = "${var.kube-dns-domain}"
     kops-state-bucket  = "${var.kops-state-bucket}"
 
@@ -106,6 +107,29 @@ EOF
   vars {
     tag   = "${element(keys(var.cloud-labels), count.index)}"
     value = "${element(values(var.cloud-labels), count.index)}"
+  }
+}
+
+data "template_file" "addons" {
+  count = "${signum(length(var.addons))}"
+
+  template = <<EOF
+  addons:
+$${addons}
+EOF
+
+  vars {
+    addons = "${join("\n", data.template_file.addons_parts.*.rendered)}"
+  }
+}
+
+data "template_file" "addons_parts" {
+  count = "${length(var.addons)}"
+
+  template = "    - $${addon}"
+
+  vars {
+    addon = "${var.addons[count.index]}"
   }
 }
 

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -15,6 +15,7 @@ spec:
   authorization:
     ${kops-authorization-mode}: {}
   channel: ${channel}
+${addons}
   cloudConfig:
     disableSecurityGroupIngress: ${disable-sg-ingress}
   cloudLabels:

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -607,3 +607,10 @@ variable "max-price" {
   description = "Spot instance max price"
   default     = ""
 }
+
+variable "addons" {
+  type        = "list"
+  description = "List of cluster addons"
+
+  default = []
+}


### PR DESCRIPTION
Like this, for instance

```
module "kops_cluster" {
  source  = "github.com/wanderaorg/karch/aws/cluster"

  addons = [
    "manifest: monitoring-standalone",
    "manifest: kubernetes-dashboard",
  ]
  [...]
}
```